### PR TITLE
Fix gh-pages base routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -16,7 +16,10 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <a
+          href={import.meta.env.BASE_URL}
+          className="text-blue-500 hover:text-blue-700 underline"
+        >
           Return to Home
         </a>
       </div>


### PR DESCRIPTION
## Summary
- fix router base path by specifying `basename` for `BrowserRouter`
- point the 404 "Return to Home" link to the project base

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844886c8abc8324a0ab6e9c00944f37